### PR TITLE
Safari fixes

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -36,7 +36,7 @@ function About() {
                   <a
                     href="#contact"
                     className="transition ease-in-out duration-300 hover:-translate-y-1 hover:scale-110 jersey text-2xl inline-flex text-gray-400 bg-gray-800 border-0 py-2 px-6 focus:outline-none focus:bg-gray-700 hover:bg-gray-700 hover:text-white rounded">
-                    <UserPlusIcon className="w-4 mr-2 text-gray-500" />
+                    <UserPlusIcon className="h-8 w-4 mr-2 text-gray-500" />
                     Connect With Me
                   </a>
                 </div>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -30,7 +30,7 @@ function Contact() {
         <div className="xl:w-1/3 md:w-2/3 lg:w-1/2 flex flex-col md:mr-auto w-full md:py-4 mt-4 md:mt-0 rounded">
           <div className="container px-5 mx-auto text-left">
             <div className="flex justify-center">
-              <ChatBubbleLeftRightIcon className="w-10 inline mb-4" />
+              <ChatBubbleLeftRightIcon className="h-12 w-10 inline mb-4" />
               <p className="text-white jersey-25 md:text-5xl text-4xl mb-1 font-medium title-font ml-4">
                 Let's connect!
               </p>


### PR DESCRIPTION
Some icons were occupying a ton of space in Safari specifically.  This PR sets their height so they don't expand any further